### PR TITLE
Add Pygments for the minted package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,5 +3,8 @@ FROM tianon/latex:latest
 RUN echo 'deb http://httpredir.debian.org/debian jessie contrib non-free' > /etc/apt/sources.list.d/contrib.list && \
     apt-get update
 
+RUN apt-get install -y python python-pip
+RUN pip install Pygments
+
 RUN apt-get install -y --no-install-recommends ttf-bitstream-vera ttf-mscorefonts-installer fonts-lato && \
     rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
The [minted package](https://github.com/gpoore/minted) formats source code blocks, but requires Pygments to do the formatting.  This PR adds Pygments.

We are then able to say...

``` tex
\usepackage{underscore,minted}
...
\begin{minted}[fontsize=\small]{scala}
import spray.json._
import shapeless._
import shapeless.ops.hlist.IsHCons
import cats.data.Xor
import cats.data.Xor.{Left, Right}

case class Currency(value: String) extends AnyVal
case class Error(value: String) extends AnyVal

trait OneFieldFormats {

  // Primitive readers and writers:

  implicit def writeString(v: String): JsValue = JsString(v)
\end{minted}
```

To get:

![review pdf page 9 of 10 2016-09-02 12-10-05](https://cloud.githubusercontent.com/assets/102661/18202127/2aef2cdc-7106-11e6-8f3e-38b7b03ed302.png)
