### PR TITLE
Update readme to reference auto build

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,12 +8,9 @@ This Docker image contains Latex and fonts etc that we use in our Latex document
 To build the image locally
 
 ```bash
-docker build -t underscoreio/latex:latest .
+docker build -t underscoreio/latex-docker:latest .
 ```
 
-To push an update to Docker Hub
+Push an update to Github and the [automated build](https://hub.docker.com/r/underscoreio/latex-docker/builds/) will trigger.
+See [Automated Builds on Docker Hub](https://docs.docker.com/docker-hub/builds/) for further details about this process.
 
-
-```bash
-docker push underscoreio/latex:latest
-```


### PR DESCRIPTION
Note that the auto build image has the same name as this repo.  The manually pushed `underscoreio:latex` still exists if you need it.
